### PR TITLE
Refactor header files for compliance and consistency

### DIFF
--- a/ring_buf.c
+++ b/ring_buf.c
@@ -31,7 +31,7 @@
 
 #include "ring_buf.h"
 
-#include <memory.h>
+#include <string.h>
 
 /*!
  * \brief Clamp a value to a specified limit.

--- a/ring_buf.h
+++ b/ring_buf.h
@@ -35,6 +35,10 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifndef EMSGSIZE
+#define EMSGSIZE 115
+#endif
+
 typedef ptrdiff_t ring_buf_ptrdiff_t;
 
 typedef size_t ring_buf_size_t;

--- a/ring_buf.h
+++ b/ring_buf.h
@@ -36,6 +36,11 @@ extern "C" {
 #include <stddef.h>
 
 #ifndef EMSGSIZE
+/*!
+ * \brief Message size error code.
+ * \details Error code indicating that a message is too large to fit in
+ * a ring buffer.
+ */
 #define EMSGSIZE 115
 #endif
 

--- a/ring_buf.h
+++ b/ring_buf.h
@@ -24,7 +24,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#pragma once
+#ifndef __RING_BUF_H__
+#define __RING_BUF_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -218,3 +219,5 @@ int ring_buf_get_all(struct ring_buf *buf, void *data, ring_buf_size_t size);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __RING_BUF_H__ */

--- a/ring_buf_circ.h
+++ b/ring_buf_circ.h
@@ -3,7 +3,8 @@
  * \brief Circular ring buffer function prototypes.
  */
 
-#pragma once
+#ifndef __RING_BUF_CIRC_H__
+#define __RING_BUF_CIRC_H__
 
 #include <stddef.h>
 
@@ -21,3 +22,5 @@ struct ring_buf;
  * size is a multiple of the item size.
  */
 int ring_buf_put_circ(struct ring_buf *buf, void *data, size_t size);
+
+#endif /* __RING_BUF_CIRC_H__ */

--- a/ring_buf_item.h
+++ b/ring_buf_item.h
@@ -24,7 +24,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#pragma once
+#ifndef __RING_BUF_ITEM_H__
+#define __RING_BUF_ITEM_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,3 +66,5 @@ int ring_buf_item_get(struct ring_buf *buf, void *item,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __RING_BUF_ITEM_H__ */

--- a/ring_buf_yield.h
+++ b/ring_buf_yield.h
@@ -5,7 +5,8 @@
  * yielding of ring buffer space to a callback function.
  */
 
-#pragma once
+#ifndef __RING_BUF_YIELD_H__
+#define __RING_BUF_YIELD_H__
 
 #include "ring_buf.h"
 
@@ -57,3 +58,5 @@ int ring_buf_get_claim_yield(struct ring_buf *buf, ring_buf_size_t size,
 int ring_buf_get_yield(struct ring_buf *buf, void *data, ring_buf_size_t size,
                        int yield(void *data, int index, void *extra),
                        void *extra);
+
+#endif /* __RING_BUF_YIELD_H__ */


### PR DESCRIPTION
Replace `#pragma once` with include guards in header files for better compatibility. Update memory header inclusion for standard compliance and ensure `EMSGSIZE` is defined in `ring_buf.h`.